### PR TITLE
bug-fix: WhatsApp web app doesn't recognize local chrome version

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,11 +1,22 @@
-const { app, BrowserWindow } = require('electron')
-var path = require('path');
+const { app, BrowserWindow, session } = require('electron')
+var path = require('path')
+
+// set user agent manually
+const userAgent = 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.80 Safari/537.36'
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let win
 
 function createWindow () {
+	// bypass error:
+	// WhatsApp works with Google Chrome 36+
+	// To use WhatsApp, update Chrome or use Mozilla Firefox, Safari, Microsoft Edge or Opera.
+	session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
+		details.requestHeaders['User-Agent'] = userAgent
+		callback({ cancel: false, requestHeaders: details.requestHeaders })
+	})
+	
   // Create the browser window.
   win = new BrowserWindow({ width: 800, height: 600, title: 'WhatsApp Linux (unofficial)', icon: path.join(__dirname, 'icons/logo256x256.png') })
 
@@ -19,12 +30,8 @@ function createWindow () {
 
   // and load the index.html of the app.
   win.loadURL('https://web.whatsapp.com')
-  //win.loadURL('file://' + __dirname+ '/index.html')
   
   win.setTitle('WhatsApp Linux (unofficial)')
-
-  // Open the DevTools.
-  //win.webContents.openDevTools()
 
   // Emitted when the window is closed.
   win.on('closed', () => {
@@ -34,8 +41,6 @@ function createWindow () {
     win = null
   })
 }
-
-
 
 
 // This method will be called when Electron has finished


### PR DESCRIPTION
bypass error: WhatsApp works with Google Chrome 36+. To use WhatsApp, update Chrome or use Mozilla Firefox, Safari, Microsoft Edge or Opera.