### PR TITLE
Tray badge changes and dark mode setting

### DIFF
--- a/main.js
+++ b/main.js
@@ -132,8 +132,13 @@ var settings = new Store({
         },
         autoHideMenuBar: {
             value: false,
-            name: "Auo-Hide Menu Bar",
+            name: "Auto-Hide Menu Bar",
             description: "Auto-hide top menu bar"
+        },
+        countMuted: {
+            value: true,
+            name: 'Include Muted Chats',
+            description: 'Count muted chats in the badge counter'
         }
     }
 });
@@ -190,11 +195,19 @@ const settingsMenu = [{
     }
 }, {
     label: settings.get('startHidden.name'),
-    sublabel: 'Keep WALC closed to Try on Start',
+    sublabel: 'Keep WALC closed to Tray on Start',
     type: 'checkbox',
     checked: settings.get('startHidden.value'),
     click: (menuItem) => {
         settings.set('startHidden.value', menuItem.checked);
+    }
+}, {
+    label: settings.get('countMuted.name'),
+    sublabel: settings.get('countMuted.description'),
+    type: 'checkbox',
+    checked: settings.get('countMuted.value'),
+    click: (menuItem) => {
+        settings.set('countMuted.value', menuItem.checked);
     }
 }, {
     label: "Update Desktop Integration",
@@ -217,7 +230,7 @@ const settingsMenu = [{
         } else {
             win.setMenuBarVisibility(true);
         }
-        win.setAutoHideMenuBar(menuItem.checked);
+        win.autoHideMenuBar(menuItem.checked);
     }
 }];
 const windowMenu = [{
@@ -390,11 +403,6 @@ function loadWA() {
     win.setMenuBarVisibility(!settings.get('autoHideMenuBar.value'));
     
     win.loadURL('https://web.whatsapp.com', { 'userAgent': userAgent }).then(async () => {
-        if(settings.get('darkMode.value')) {
-            win.webContents.send("enableDarkMode");
-        } else {
-            win.webContents.send("disableDarkMode");
-        }
         pie.connect(app, puppeteer).then(async (b) => {
             pieBrowser = b;
             let page;
@@ -499,14 +507,14 @@ function createWindow() {
         height: windowState.height,
         title: 'WALC',
         icon: path.join(__dirname, 'icons/logo256x256.png'),
-        'webPreferences': {
-            'nodeIntegration': true,
+        webPreferences: {
+            nodeIntegration: true,
             preload: `${__dirname}/preload.js`,
         },
         show: !settings.get('startHidden.value'),
+        autoHideMenuBar: settings.get('autoHideMenuBar.value'),
     });
     win.setMenuBarVisibility(!settings.get('autoHideMenuBar.value'));
-    win.setAutoHideMenuBar(settings.get('autoHideMenuBar.value'));
     win.setAlwaysOnTop(settings.get('alwaysOnTop.value'));
     trayIcon = new Tray(path.join(__dirname, 'icons/logo256x256.png'));
     //Hide Default menubar

--- a/main.js
+++ b/main.js
@@ -231,7 +231,7 @@ const settingsMenu = [{
         } else {
             win.setMenuBarVisibility(true);
         }
-        win.autoHideMenuBar(menuItem.checked);
+        win.autoHideMenuBar = menuItem.checked;
     }
 }];
 const windowMenu = [{

--- a/main.js
+++ b/main.js
@@ -208,6 +208,7 @@ const settingsMenu = [{
     checked: settings.get('countMuted.value'),
     click: (menuItem) => {
         settings.set('countMuted.value', menuItem.checked);
+        win.webContents.send('renderTray');
     }
 }, {
     label: "Update Desktop Integration",

--- a/preload.js
+++ b/preload.js
@@ -107,5 +107,6 @@ function disableDarkMode() {
 
 window.addEventListener('load', storeOnLoad);
 window.addEventListener('load', applySettings);
+ipcRenderer.on('renderTray', renderTray);
 ipcRenderer.on('enableDarkMode', enableDarkMode);
 ipcRenderer.on('disableDarkMode', disableDarkMode);


### PR DESCRIPTION
Resolves #37 
Added option to count muted chats, on by default.
When all unread chats are muted, tray badge is gray.
Tray icon become b/w when disconnected.
Added delay when checking AppState to not display notifications randomly.
Dark mode is applied directly from preload.js.
Fixed some typos.
Replaced the now deprecated `setAuhideMenubar` method with `autoHideMenuBar` property