### PR TITLE
Fix issue #39

### DIFF
--- a/main.js
+++ b/main.js
@@ -34,7 +34,7 @@ let preventTitleChange = true;
 
 lsbRelease(function (_, data) {
     aboutWALC = `Installation Type: ${process.env.APPIMAGE ? "AppImage" : ((isSNAP) ? "Snap" : "Manual")}
-${isSNAP ? `Snap Version:${process.env.SNAP_VERSION}(${process.env.SNAP_REVISION})` : ""}OS: ${data ? data.description : "unknown (probably missing lsb_release)"}
+${isSNAP ? `Snap Version:${process.env.SNAP_VERSION}(${process.env.SNAP_REVISION})` : ""}OS: ${data ? data.description : "Unknown (probably missing lsb_release)"}
 `;
 });
 

--- a/main.js
+++ b/main.js
@@ -34,7 +34,7 @@ let preventTitleChange = true;
 
 lsbRelease(function (_, data) {
     aboutWALC = `Installation Type: ${process.env.APPIMAGE ? "AppImage" : ((isSNAP) ? "Snap" : "Manual")}
-${isSNAP ? `Snap Version:${process.env.SNAP_VERSION}(${process.env.SNAP_REVISION})` : ""}OS: ${data.description} 
+${isSNAP ? `Snap Version:${process.env.SNAP_VERSION}(${process.env.SNAP_REVISION})` : ""}OS: ${data ? data.description : "unknown (probably missing lsb_release)"}
 `;
 });
 


### PR DESCRIPTION
This should prevent a JS error message when the user's OS is missing the lsb_release CLI tool. The OS description string in the about dialog then becomes "unknown (probably missing lsb_release)". It seemed a bit silly to me to spam a JS error and break the about dialog entirely when a CLI tool that apparently doesn't exist by default on many distros in fact doesn't exist.

Tested only on my local OpenSUSE 15.0 machine, with and without the lsb-release installed.

I'm not a JS developer at all, so let me know if I did something silly, or edit it however. In case it matters (since there doesn't seem to be a CLA), feel free to use, (re)license, or ignore the contents of this PR however you want now or in the future.