### PR TITLE
add launcher script when installed with npm install. Fixes #61

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env electron
+
 const { app, BrowserWindow, session, Menu, dialog, Tray, remote, ipcMain, nativeImage, Notification, shell, clipboard } = require('electron');
 const { autoUpdater } = require("electron-updater");
 const { Client } = require('./WhatsBot/index');

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "start": "electron .",
     "dist": "rm -r dist && electron-builder --dir && cp /usr/lib/x86_64-linux-gnu/libXtst.so.6 dist/linux-unpacked/ && cp /usr/lib/x86_64-linux-gnu/libXss.so.1 dist/linux-unpacked/ && electron-builder --prepackaged dist/linux-unpacked"
   },
+  "bin": {
+    "walc": "main.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/cstayyab/WALC.git"


### PR DESCRIPTION
This allows another way of installing WALC without appimage or snap.  Users can install using `npm install -g https://github.com/cstayyab/WALC.git`

Fixes https://github.com/cstayyab/WALC/issues/61