### PR TITLE
Updated Help Menu - #87

### DIFF
--- a/main.js
+++ b/main.js
@@ -306,6 +306,7 @@ const helpMenu = [{
 }, {
     label: 'Vote for a Feature',
     sublabel: 'Vote for existing features on FeatHub',
+    visible: false,
     click: () => {
         shell.openExternal("https://feathub.com/cstayyab/WALC");
     }

--- a/main.js
+++ b/main.js
@@ -283,9 +283,9 @@ const windowMenu = [{
 
 const helpMenu = [{
     label: 'Find Help',
-    sublabel: 'View Related Issues on GitHub',
+    sublabel: 'Get Help on WALC Troubleshooting Board',
     click: () => {
-        shell.openExternal(walcinfo.bugs.url);
+        shell.openExternal("https://github.com/cstayyab/WALC/discussions/categories/troubleshooting");
     },
     accelerator: 'F1'
 }, {

--- a/main.js
+++ b/main.js
@@ -301,7 +301,7 @@ const helpMenu = [{
     label: 'Request a Feature',
     sublabel: 'Create a new feature request on GitHub',
     click: () => {
-        shell.openExternal(walcinfo.bugs.url + "/new/?template=feature_request.md&labels=enhancement&title=[Feature+Request]");
+        shell.openExternal("https://github.com/cstayyab/WALC/discussions/categories/feature-requests");
     }
 }, {
     label: 'Vote for a Feature',


### PR DESCRIPTION
Fixes for Issue #87

Updated with the requested `visible` prop changes

- Redirect "Find Help" menu to Troubleshooting Discussion Board and update its sublabel to "Get Help on WALC Troubleshooting Board"

- Redirect "Request a Feature" menu to Feature Requests Discussion Board

- Hide "Vote for a Feature" menu for the time being but do not fully remove it.